### PR TITLE
Disable 'use fully qualified class name' option

### DIFF
--- a/configs/raywenderlich_com.xml
+++ b/configs/raywenderlich_com.xml
@@ -15,7 +15,7 @@
   <option name="LINE_SEPARATOR" value="&#10;" />
   <option name="FIELD_NAME_PREFIX" value="m" />
   <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
-  <option name="USE_FQ_CLASS_NAMES" value="true" />
+  <option name="USE_FQ_CLASS_NAMES" value="false" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">


### PR DESCRIPTION
With 'Use fully qualified class names' option enabled when I try to auto-import Intent class for the line:
 `Intent intent;`
I'm getting class name replaced and the line changes to:
`android.content.Intent intent;`.

It doesn't look like that improves readability. I expect `import android.content.Intent;` to be generated instead.
